### PR TITLE
詳細画面の郵便番号(緊急)が101-0032固定となっていた不具合解消

### DIFF
--- a/views/detail.ejs
+++ b/views/detail.ejs
@@ -110,7 +110,7 @@ if (result.retireDate) {
 		</tr>
 		<tr>
 			<td>郵便番号(緊急)</td>
-			<td colspan="3">101-0032</td>
+			<td colspan="3"><%= result.zipHome%></td>
 		</tr>
 		<tr>
 			<td>住所(緊急)</td>


### PR DESCRIPTION
詳細画面の郵便番号(緊急)の固定表記をやめてDB取得にする