### PR TITLE
退職年検索以外で退職者が表示されないようにする

### DIFF
--- a/views/list.ejs
+++ b/views/list.ejs
@@ -46,7 +46,7 @@
 
 <div class="searchResult-box">
 	<div class="searchResult-count-box">
-		検索結果<label id="searchResult-count"><%= result.length %></label>件です(退職者<%= countResigned.COUNT%>件)
+		検索結果<label id="searchResult-count"><%= result.length %></label>件です
 	</div>
 	<table class="searchResult-table">
 		<tr>


### PR DESCRIPTION
要件：https://central-soft.atlassian.net/wiki/spaces/SRT/pages/28311574
>この機能提供に合わせて、一覧上では現職／退職が混在しないようにしたい

とのことなので、検索条件なしで全件検索する場合も下記のように検索対象を現職/退職に分けました。
退職年検索以外→現職社員を検索対象に
退職年検索→退職社員を検索対象に